### PR TITLE
feat: remove obsolete files

### DIFF
--- a/migration/src/main/java/com/intershop/customization/migration/Migrator.java
+++ b/migration/src/main/java/com/intershop/customization/migration/Migrator.java
@@ -92,7 +92,7 @@ public class Migrator
      * Initializes the git repository for the project.
      *
      * @param autoCommit if true, the git repository will be initialized and changes will be committed automatically
-     * @param projectPath
+     * @param projectPath the path to the project directory
      */
     public void initializeGitRepository(boolean autoCommit, File projectPath)
     {
@@ -122,12 +122,16 @@ public class Migrator
     protected void migrateProjects(File rootProject)
     {
         MigrationStepFolder steps = MigrationStepFolder.valueOf(migrationStepFolder.toPath());
+
+        // migrate root project
         for (MigrationStep step: steps.getSteps())
         {
             MigrationPreparer migrator = step.getMigrator();
             migrator.migrateRoot(rootProject.toPath());
             gitRepository.ifPresent(r -> commitChanges(r, step));
         }
+
+        // migrate all cartridges
         for (MigrationStep step: steps.getSteps())
         {
             MigrationPreparer migrator = step.getMigrator();

--- a/migration/src/main/java/com/intershop/customization/migration/file/MoveFilesConstants.java
+++ b/migration/src/main/java/com/intershop/customization/migration/file/MoveFilesConstants.java
@@ -1,4 +1,4 @@
-package com.intershop.customization.migration.moving;
+package com.intershop.customization.migration.file;
 
 public class MoveFilesConstants
 {

--- a/migration/src/main/java/com/intershop/customization/migration/file/MoveFolder.java
+++ b/migration/src/main/java/com/intershop/customization/migration/file/MoveFolder.java
@@ -1,36 +1,32 @@
-package com.intershop.customization.migration.moving;
+package com.intershop.customization.migration.file;
 
 import com.intershop.customization.migration.common.MigrationPreparer;
 import com.intershop.customization.migration.common.MigrationStep;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.Map;
 
-import static com.intershop.customization.migration.moving.MoveFilesConstants.PLACEHOLDER_CARTRIDGE_NAME;
+import static com.intershop.customization.migration.file.MoveFilesConstants.PLACEHOLDER_CARTRIDGE_NAME;
 
-public class MoveFiles implements MigrationPreparer
+public class MoveFolder implements MigrationPreparer
 {
     private final Logger LOGGER = LoggerFactory.getLogger(getClass());
 
     private static final String YAML_KEY_SOURCE_MAP = "source-map";
     private static final String YAML_KEY_TARGET_MAP = "target-map";
-    private static final String YAML_KEY_FILTER_MAP = "filter-map";
     private Map<String, String> sourceConfiguration = Collections.emptyMap();
     private Map<String, String> targetConfiguration = Collections.emptyMap();
-    private Map<String, String> filterConfiguration = Collections.emptyMap();
 
     @Override
     public void setStep(MigrationStep step)
     {
         this.sourceConfiguration = step.getOption(YAML_KEY_SOURCE_MAP);
         this.targetConfiguration = step.getOption(YAML_KEY_TARGET_MAP);
-        this.filterConfiguration = step.getOption(YAML_KEY_FILTER_MAP);
     }
 
     public void migrate(Path cartridgeDir)
@@ -44,50 +40,32 @@ public class MoveFiles implements MigrationPreparer
             Path sourcePath = cartridgeDir.resolve(sourceEntry.getValue().replace(PLACEHOLDER_CARTRIDGE_NAME, cartridgeName));
             if (!sourcePath.toFile().exists())
             {
-                LOGGER.debug("Can't find cartridges folder {}.", sourcePath);
+                LOGGER.debug("Can't find cartridges folder '{}'.", sourcePath);
                 continue;
             }
             String targetPathAsString = targetConfiguration.get(artifactName);
             Path targetPath = cartridgeDir.resolve(targetPathAsString.replace(PLACEHOLDER_CARTRIDGE_NAME, cartridgeName));
-            // create target if not exists
-            if (!targetPath.toFile().exists())
+            // move everything at once
+            try
             {
-                targetPath.toFile().mkdirs();
-            }
-            File[] files = sourcePath.toFile().listFiles();
-            if (files != null)
-            {
-                for(File file : files)
+                // create parent if not exists (required by Files.move)
+                if (!targetPath.getParent().toFile().exists())
                 {
-                    if (file.isDirectory())
-                    {
-                        continue;
-                    }
-                    String fileName = file.getName();
-                    if (!shouldMigrate(fileName, artifactName))
-                    {
-                        continue;
-                    }
-                    Path targetFile = targetPath.resolve(fileName);
-                    try
-                    {
-                        Files.move(file.toPath(), targetFile);
-                    }
-                    catch(IOException e)
-                    {
-                        throw new RuntimeException(e);
-                    }
+                    targetPath.getParent().toFile().mkdirs();
+                }
+                // target must not exist (required by Files.move)
+                if (!targetPath.toFile().exists())
+                {
+                    Files.move(sourcePath, targetPath);
+                }
+                else {
+                    LoggerFactory.getLogger(getClass()).warn("Folder '{}' exists.", targetPath);
                 }
             }
+            catch(IOException e)
+            {
+                throw new RuntimeException(e);
+            }
         }
-    }
-
-    private boolean shouldMigrate(String fileName, String artifactName)
-    {
-        if (filterConfiguration.containsKey(artifactName))
-        {
-            return fileName.matches(filterConfiguration.get(artifactName));
-        }
-        return false;
     }
 }

--- a/migration/src/main/java/com/intershop/customization/migration/file/RemoveFiles.java
+++ b/migration/src/main/java/com/intershop/customization/migration/file/RemoveFiles.java
@@ -1,0 +1,99 @@
+package com.intershop.customization.migration.file;
+
+import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.intershop.customization.migration.common.MigrationPreparer;
+import com.intershop.customization.migration.common.MigrationStep;
+
+/**
+ * This class is used to remove files from a cartridge directory based on the
+ * configuration of the migration step
+ * <p>
+ * The configuration is defined in the migration step and contains a map of
+ * patterns to match files for deletion. The keys of the map are the
+ * pattern types (glob or regex) and the values are the patterns to match.
+ * See {@link java.nio.file.FileSystem#getPathMatcher(String)} for more details.
+ * <p>
+ * Deletion of Directories is not supported by this migration preparer.
+ * <p>
+ * Example YAML configuration:
+ * <pre>
+ * type: specs.intershop.com/v1beta/migrate
+ * migrator: migrator: com.intershop.customization.migration.file.RemoveFiles
+ * message: "refactor: removed *.bak files"
+ * options:
+ *   glob:
+ *   - "*.bak"
+ *   regex:
+ *   - "*\\.bak$"
+ * </pre>
+ */
+public class RemoveFiles implements MigrationPreparer
+{
+    private final Logger LOGGER = LoggerFactory.getLogger(getClass());
+
+    private static final String YAML_KEY_GLOB = "glob";
+    private static final String YAML_KEY_REGEX = "regex";
+
+    private List<String> globPattern = Collections.emptyList();
+    private List<String> regexPattern = Collections.emptyList();
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void setStep(MigrationStep step)
+    {
+        this.globPattern = (List<String>)Optional.ofNullable(step.getOption(YAML_KEY_GLOB))
+                                                 .orElse(Collections.emptyList());
+        this.regexPattern = (List<String>)Optional.ofNullable(step.getOption(YAML_KEY_REGEX))
+                                                  .orElse(Collections.emptyList());
+    }
+
+    public void migrate(Path cartridgeDir)
+    {
+        String cartridgeName = getResourceName(cartridgeDir);
+        LOGGER.info("Processing cartridge {}.", cartridgeName);
+
+        globPattern.forEach(pattern -> deleteByPattern(cartridgeDir, YAML_KEY_GLOB, pattern));
+        regexPattern.forEach(pattern -> deleteByPattern(cartridgeDir, YAML_KEY_REGEX, pattern));
+    }
+
+    private void deleteByPattern(Path cartridgeDir, String patternType, String pattern)
+    {
+        LOGGER.debug("Deleting files with '{}' pattern '{}'", patternType, pattern);
+
+        PathMatcher matcher = FileSystems.getDefault().getPathMatcher(patternType + ":" + pattern);
+
+        try (Stream<Path> pathStream = Files.list(cartridgeDir))
+        {
+            pathStream
+                .filter(Files::isRegularFile)
+                .filter(path -> matcher.matches(path.getFileName()))
+                .forEach(file -> {
+                    LOGGER.info("Deleting file: '{}'", file);
+                    try
+                    {
+                        Files.delete(file);
+                    }
+                    catch (IOException e)
+                    {
+                        LOGGER.error("Error while deleting file '{}': {}", file, e.getMessage());
+                    }
+                });
+        }
+        catch (IOException e)
+        {
+            LOGGER.error("Error while resolving files of '{}': {}", cartridgeDir, e.getMessage());
+        }
+    }
+}

--- a/migration/src/main/resources/migration/001_migration_7.10-11.0.8/008_DeleteVersionFiles.yml
+++ b/migration/src/main/resources/migration/001_migration_7.10-11.0.8/008_DeleteVersionFiles.yml
@@ -1,0 +1,6 @@
+type: specs.intershop.com/v1beta/migrate
+migrator: com.intershop.customization.migration.file.RemoveFiles
+message: "refactor: removed obsolete *.version files"
+options:
+  glob:
+    - "*.version"

--- a/migration/src/main/resources/migration/001_migration_7.10-11.0.8/008_DeleteVersionFiles.yml
+++ b/migration/src/main/resources/migration/001_migration_7.10-11.0.8/008_DeleteVersionFiles.yml
@@ -1,6 +1,0 @@
-type: specs.intershop.com/v1beta/migrate
-migrator: com.intershop.customization.migration.file.RemoveFiles
-message: "refactor: removed obsolete *.version files"
-options:
-  glob:
-    - "*.version"

--- a/migration/src/main/resources/migration/001_migration_7.10-11.0.8/100_DeleteObsoleteFiles.yml
+++ b/migration/src/main/resources/migration/001_migration_7.10-11.0.8/100_DeleteObsoleteFiles.yml
@@ -1,0 +1,9 @@
+type: specs.intershop.com/v1beta/migrate
+migrator: com.intershop.customization.migration.file.RemoveFiles
+message: "refactor: removed obsolete files"
+options:
+  root-project:
+    glob:
+      - "*.version"
+      - "build.gradle"
+      - "settings.gradle"


### PR DESCRIPTION
Added functionality to remove obsolete files. Migration preparer registered in the list with a low priority so others can be added before. 
Current configuration removes remaining `*.version` files as well as `build.gradle` and `settings.gradle` from root project.