### PR TITLE
feat: read version file content and integrate into versions/build.gradle

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ How to Work with the ICM Migration Support
 - $ICM is a symbolic marker for the root directory of your ICM 7.10 project
 - $ICM_11 is a symbolic marker for the root directory of your ICM 11+ project (template)
 
+# Before you start
+
+TODO  backup
+
+
 # Prerequisites
 
 Retrieve customization template and follow the prerequisites steps.

--- a/migration/src/main/java/com/intershop/customization/migration/common/Position.java
+++ b/migration/src/main/java/com/intershop/customization/migration/common/Position.java
@@ -26,7 +26,7 @@ public class Position
         int counterBrackets = 0;
         for (int i = 0; i < lines.size(); i++)
         {
-            String line = lines.get(i);
+            String line = lines.get(i).trim();
             if (line.startsWith(startMarker))
             {
                 startIntershop = i;
@@ -79,6 +79,30 @@ public class Position
         result.addAll(lines.subList(0, this.begin));
         result.addAll(lines.subList(this.end + 1, lines.size()));
         return result;
+    }
+
+    /**
+     * @return lines which are not included in and before the identified position
+     */
+    public List<String> nonMatchingLinesBefore()
+    {
+        if (this.begin == -1)
+        {
+            return lines;
+        }
+        return lines.subList(0, this.begin);
+    }
+
+    /**
+     * @return lines which are not included in and after the identified position
+     */
+    public List<String> nonMatchingLinesAfter()
+    {
+        if (this.begin == -1)
+        {
+            return lines;
+        }
+        return lines.subList(this.end + 1, lines.size());
     }
 
     /**

--- a/migration/src/main/java/com/intershop/customization/migration/gradle/MigrateVersionFiles.java
+++ b/migration/src/main/java/com/intershop/customization/migration/gradle/MigrateVersionFiles.java
@@ -1,0 +1,224 @@
+package com.intershop.customization.migration.gradle;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.intershop.customization.migration.common.MigrationPreparer;
+import com.intershop.customization.migration.common.Position;
+
+/**
+ * This class is used to parse version files (except: 'intershopBuild.version', '.ivy*.version', '.pom*.version')
+ * and integrate the version information containing information about the artifact group, name and version
+ * into the `versions/build.gradle` file.
+ * <p>
+ * Migration to Kotlin is out of scope for this step and performed later in a separate step.
+ * <p>
+ * Example YAML configuration:
+ * <pre>
+ * type: specs.intershop.com/v1beta/migrate
+ * migrator: com.intershop.customization.migration.gradle.MigrateVersionFiles
+ * message: "refactor: transfer data from '*.version' files into 'versions/build.gradle'"
+ * </pre>
+ */
+public class MigrateVersionFiles implements MigrationPreparer
+{
+    private final Logger LOGGER = LoggerFactory.getLogger(getClass());
+
+    private static final Charset CHARSET_BUILD_GRADLE = Charset.defaultCharset();
+    private static final String LINE_SEP = System.lineSeparator();
+    private static final String START_CONSTRAINTS = "constraints";
+    public static final String EMPTY = "";
+
+    @Override
+    public void migrateRoot(Path projectDir)
+    {
+        List<Path> versionFiles = collectVersionFiles(projectDir);
+
+        if (versionFiles.isEmpty())
+        {
+            LOGGER.info("No version files to migrate found in '{}'.", projectDir);
+            return;
+        }
+
+        Map<String, Collection<String>> collectedVersionData = collectMigratedVersionData(versionFiles);
+        if (collectedVersionData.isEmpty())
+        {
+            LOGGER.info("No version data to be migrated in '{}'.", projectDir);
+            return;
+        }
+
+        Path versionsBuild = projectDir.resolve("versions").resolve("build.gradle");
+        try (Stream<String> linesStream = Files.lines(versionsBuild, CHARSET_BUILD_GRADLE))
+        {
+            Files.writeString(versionsBuild, migrate(linesStream.toList(), collectedVersionData), CHARSET_BUILD_GRADLE);
+        }
+        catch(IOException e)
+        {
+            LOGGER.error("Can't migrate *.version files to 'versions' project", e);
+        }
+    }
+
+    @Override
+    public void migrate(Path resource)
+    {
+        // nothing to do on subproject level (for now
+    }
+
+    /**
+     * go step by step through migration steps to fix gradle build
+     * @param lines lines to migrate
+     * @param collectedVersionData map of version data comprised of filename (key) and migrated version information (value)
+     * @return new content of versions/build.gradle
+     */
+    String migrate(List<String> lines, Map<String, Collection<String>> collectedVersionData)
+    {
+        Position constraintsPos = Position.findBracketBlock(START_CONSTRAINTS, lines)
+                                          .orElse(Position.NOT_FOUND(lines));
+        List<String> constraintsLines = constraintsPos.matchingLines();
+        List<String> beforeConstraintsLines = constraintsPos.nonMatchingLinesBefore();
+        List<String> afterConstraintsLines = constraintsPos.nonMatchingLinesAfter();
+
+        List<String> migratedConstraintsLines = new ArrayList<>();
+        boolean first = true;
+        for (String line : constraintsLines)
+        {
+            migratedConstraintsLines.add(line);
+
+            // add migrated version information direct after the constraints block started
+            if (first)
+            {
+                migratedConstraintsLines.add(EMPTY); // empty line
+                collectedVersionData.entrySet().stream()
+                                .flatMap(entry -> {
+                                    migratedConstraintsLines.add("        # migrated version information of '" + entry.getKey() + "'");
+                                    return entry.getValue().stream();
+                                })
+                                .map(migratedLine -> ("        api \"" + migratedLine + "\"")).forEach(migratedConstraintsLines::add);
+
+                migratedConstraintsLines.add(EMPTY); // empty line
+                first = false;
+            }
+        }
+
+        // build result: start with code before constraints block
+        String result = String.join(LINE_SEP, beforeConstraintsLines) + LINE_SEP;
+        // now add adapted constraints block
+        result += String.join(LINE_SEP, migratedConstraintsLines) + LINE_SEP;
+        // finally add remaining code (after constraints block)
+        result += String.join(LINE_SEP, afterConstraintsLines) + LINE_SEP;
+
+        return result;
+    }
+
+    /**
+     * Collects version files to migrate in the given project directory.
+     * @param projectDir the project directory
+     * @return a list of version files
+     */
+    protected List<Path> collectVersionFiles(Path projectDir)
+    {
+        PathMatcher matcher = FileSystems.getDefault().getPathMatcher("glob:*.version");
+        PathMatcher excludeMatcher = FileSystems.getDefault().getPathMatcher("glob:{.ivy*,.pom*,intershopBuild}.version");
+
+        try (Stream<Path> pathStream = Files.list(projectDir))
+        {
+            return pathStream
+                        .filter(Files::isRegularFile)
+                        .filter(path -> matcher.matches(path.getFileName()))
+                        .filter(path -> !excludeMatcher.matches(path.getFileName()))
+                        .toList();
+        }
+        catch (IOException e)
+        {
+            LOGGER.error("Error while resolving files of '{}': {}", projectDir, e.getMessage());
+        }
+        return Collections.emptyList();
+    }
+
+    /**
+     * Collects the data of the version files to migrate in the given project directory.
+     * @param versionFiles list of version files to process
+     * @return a map of version data, where the key is the filename and the value is a collection of migrated version data
+     */
+    protected Map<String, Collection<String>> collectMigratedVersionData(List<Path> versionFiles)
+    {
+        Map<String, Collection<String>> versionData = new HashMap<>();
+        Collection<String> migratedVersions = new HashSet<>();
+        for (Path versionFile : versionFiles)
+        {
+            LOGGER.info("Migrating version information for '{}'", versionFile);
+            try (Stream<String> versionFileStream = Files.lines(versionFile, CHARSET_BUILD_GRADLE))
+            {
+                migratedVersions.addAll(
+                    versionFileStream.toList().stream()
+                                     .map(this::migrateVersion)
+                                     .filter(Objects::nonNull)
+                                     .collect(Collectors.toSet()));
+
+                versionData.put(versionFile.getFileName().toString(), migratedVersions);
+                deleteFile(versionFile);
+            }
+            catch (IOException e)
+            {
+                LOGGER.error("Can't read file '{}'", versionFile, e);
+            }
+        }
+
+        return versionData;
+    }
+
+    /**
+     * Migrates the version line to the format "group:name:version".
+     * @param line the line containing the version data to migrate
+     * @return the migrated line in the format "group:name:version" or null if the line is not in the expected format
+     */
+    protected String migrateVersion(String line)
+    {
+        if (line.isEmpty() || line.startsWith("#"))
+        {
+            return line;
+        }
+
+        if (!line.contains("="))
+        {
+            return null;
+        }
+
+        return line.replace(" ", EMPTY).replace("=", ":");
+    }
+
+
+    /**
+     * Deletes the given file.
+     * @param file file to delete
+     */
+    protected void deleteFile(Path file)
+    {
+        LOGGER.info("Deleting file: '{}'", file);
+        try
+        {
+            Files.delete(file);
+        }
+        catch (IOException e)
+        {
+            LOGGER.error("Error while deleting file '{}': {}", file, e.getMessage());
+        }
+    }
+}

--- a/migration/src/main/resources/migration/001_migration_7.10-11.0.8/008_MigrateVersions.yml
+++ b/migration/src/main/resources/migration/001_migration_7.10-11.0.8/008_MigrateVersions.yml
@@ -1,0 +1,3 @@
+type: specs.intershop.com/v1beta/migrate
+migrator: com.intershop.customization.migration.gradle.MigrateVersionFiles
+message: "refactor: transfer data from '*.version' files into 'versions/build.gradle'"


### PR DESCRIPTION
read `*.version`friles of root project and integrate into `versions/build.gradle` if group, name and version are given. the notation of the `.ivy*.version` and `.pom*.version` are ignored since their handling was replaced.
After migration the files are deleted.