### PR TITLE
feature/add site content preparer

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,10 +109,11 @@ subprojects {
             implementation ("org.apache.tomcat:tomcat-servlet-api")
 ...
 ```
-### Sites Folder Copy Tasks
+### Remove Sites Folder Copy Tasks
 
 Remove site tasks from build.gradle files, like the following example.
-The content of sites folder will be prepared as dbprepare step.
+The content of `sites` folder will be prepared as dbprepare step. The required `SiteContentPerparer` will be added for these subprojects 
+where such a folder exists.
 
 ```
 /*
@@ -125,11 +126,6 @@ task copySimpleSMBWhiteStore(type: Copy) {
 zipShare.dependsOn copySimpleSMBWhiteStore
 ```
 
-Add the migration task to the `dbinit.properties` or desired `migration-to-xxx.properties` 
-```
-# Prepare sites-folder
-pre.Class0=com.intershop.site.dbinit.SiteContentPreparer
-```
 
 ### Remove assembly projects
 

--- a/migration/src/main/java/com/intershop/customization/migration/Migrator.java
+++ b/migration/src/main/java/com/intershop/customization/migration/Migrator.java
@@ -155,7 +155,6 @@ public class Migrator
         for(MigrationStep step: steps.getSteps())
         {
             MigrationPreparer migrator = step.getMigrator();
-            LOGGER.info(">>> Executing migration step '{}' for project.", migrator.getClass().getName());
 
             migrator.migrate(projectDir.toPath());
             gitRepository.ifPresent(r -> commitChanges(r, step));

--- a/migration/src/main/java/com/intershop/customization/migration/gradle/AddSiteContentPreparer.java
+++ b/migration/src/main/java/com/intershop/customization/migration/gradle/AddSiteContentPreparer.java
@@ -57,13 +57,13 @@ public class AddSiteContentPreparer implements MigrationPreparer
                 DBInitPropertiesParser.PropertyEntry firstMainEntry = parser.getFirstEntry( DBInitPropertiesParser.GroupType.MAIN);
 
                 Files.writeString(dbinitProperties, injectSiteContentPreparer(parsedLines, highestPreEntry, firstMainEntry), CHARSET_BUILD_GRADLE);
+
+                LOGGER.warn("SiteContentPreparer was added to file '{}'. Please remove possible 'Copy' tasks from '{}'", dbinitProperties, projectDir.resolve("build.gradle"));
             }
             catch(IOException e)
             {
                 LOGGER.error("Can't register SiteContentPreparer in file " + dbinitProperties, e);
             }
-
-            // TODO remove possible enries in build.gradle (copy tasks)
         }
     }
 

--- a/migration/src/main/java/com/intershop/customization/migration/gradle/AddSiteContentPreparer.java
+++ b/migration/src/main/java/com/intershop/customization/migration/gradle/AddSiteContentPreparer.java
@@ -53,8 +53,8 @@ public class AddSiteContentPreparer implements MigrationPreparer
 
                 DBInitPropertiesParser parser = new DBInitPropertiesParser(lines);
                 List<DBInitPropertiesParser.LineEntry> parsedLines = parser.getParsedLines();
-                DBInitPropertiesParser.PropertyEntry highestPreEntry = parser.getFirstEntry( DBInitPropertiesParser.GroupType.PRE);
-                DBInitPropertiesParser.PropertyEntry firstMainEntry = parser.getFirstEntry( DBInitPropertiesParser.GroupType.MAIN);
+                DBInitPropertiesParser.PropertyEntry highestPreEntry = parser.getHighestIdEntry(DBInitPropertiesParser.GroupType.PRE);
+                DBInitPropertiesParser.PropertyEntry firstMainEntry = parser.getFirstEntry(DBInitPropertiesParser.GroupType.MAIN);
 
                 Files.writeString(dbinitProperties, injectSiteContentPreparer(parsedLines, highestPreEntry, firstMainEntry), CHARSET_BUILD_GRADLE);
 
@@ -94,7 +94,7 @@ public class AddSiteContentPreparer implements MigrationPreparer
         Path newSitesFolder = cartridgeResources.resolve("sites");
         if (newSitesFolder.toFile().isDirectory() && newSitesFolder.toFile().exists())
         {
-            LOGGER.debug("project contains 'sites' folder at '{}'", oldSitesFolder);
+            LOGGER.debug("project contains 'sites' folder at '{}'", newSitesFolder);
             return Optional.of(newSitesFolder);
         }
 

--- a/migration/src/main/java/com/intershop/customization/migration/gradle/AddSiteContentPreparer.java
+++ b/migration/src/main/java/com/intershop/customization/migration/gradle/AddSiteContentPreparer.java
@@ -1,0 +1,208 @@
+package com.intershop.customization.migration.gradle;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.intershop.customization.migration.common.MigrationPreparer;
+
+/**
+ * This class is used to
+ * <p>
+ * Example YAML configuration:
+ * <pre>
+ * type: specs.intershop.com/v1beta/migrate
+ * migrator: com.intershop.customization.migration.gradle.AddSiteContentPreparer
+ * message: "refactor: inject SiteContentPreparer into 'dbinit.properties'"
+ * </pre>
+ */
+public class AddSiteContentPreparer implements MigrationPreparer
+{
+    private final Logger LOGGER = LoggerFactory.getLogger(getClass());
+
+    private static final Charset CHARSET_BUILD_GRADLE = Charset.defaultCharset();
+    private static final String LINE_SEP = System.lineSeparator();
+
+    @Override
+    public void migrate(Path projectDir)
+    {
+        LOGGER.debug("starting SiteContent migration for project {}", projectDir);
+        Optional<Path> sitesFolderOptional = getSitesFolder(projectDir);
+
+        if (sitesFolderOptional.isPresent())
+        {
+            // sites folder found - get or create dbinit.properties
+            Path dbinitProperties = getDBinitProperties(projectDir);
+
+            try (Stream<String> linesStream = Files.lines(dbinitProperties, CHARSET_BUILD_GRADLE))
+            {
+                List<String> lines = linesStream.toList();
+                if (lines.stream().anyMatch(l -> l.contains("com.intershop.site.dbinit.SiteContentPreparer")))
+                {
+                    LOGGER.debug("SiteContentPreparer already registered in file '{}'. Nothing to do.", dbinitProperties);
+                    return;
+                }
+
+                Files.writeString(dbinitProperties, injectSiteContentPreparer(lines), CHARSET_BUILD_GRADLE);
+            }
+            catch(IOException e)
+            {
+                LOGGER.error("Can't register SiteContentPreparer in file " + dbinitProperties, e);
+            }
+
+            // TODO remove possible enries in build.gradle (copy tasks)
+        }
+
+    }
+
+    /**
+     * Looks up and returns the sites folder of the cartridge. It checks the
+     * old location first and then the new location.
+     *
+     * @param projectDir the project dir to check.
+     * @return the sites folder of the cartridge, if present. If not, an empty
+     *         optional is returned.
+     */
+    protected Optional<Path> getSitesFolder(Path projectDir)
+    {
+        Path oldSitesFolder = projectDir.resolve("staticfiles").resolve("share").resolve("sites");
+
+        if (oldSitesFolder.toFile().isDirectory() && oldSitesFolder.toFile().exists())
+        {
+            LOGGER.debug("project contains 'sites' folder at '{}'", oldSitesFolder);
+            return Optional.of(oldSitesFolder);
+        }
+
+        String cartridgeName = getResourceName(projectDir);
+        Path cartridgeResources = projectDir.resolve("src")
+                                            .resolve("main")
+                                            .resolve("resources")
+                                            .resolve("resources")
+                                            .resolve(cartridgeName);
+        Path newSitesFolder = cartridgeResources.resolve("sites");
+        if (newSitesFolder.toFile().isDirectory() && newSitesFolder.toFile().exists())
+        {
+            LOGGER.debug("project contains 'sites' folder at '{}'", oldSitesFolder);
+            return Optional.of(newSitesFolder);
+        }
+
+        return Optional.empty();
+    }
+
+    /**
+     * Looks up the 'dbinit.properties' file. The new location is preferred.
+     * If the file is not found there, the old location is checked.
+     * The method bases on the precondition that the 'sites' folder was
+     * found and the SiteContentPreparer has to be present in the 'dbinit.properties'.
+     * Means a new file will be created in the new location, if no other was found.
+     *
+     * @param projectDir the project dir to check.
+     * @return the dbinit.properties file of the cartridge.
+     */
+    protected Path getDBinitProperties(Path projectDir)
+    {
+        String cartridgeName = getResourceName(projectDir);
+        Path cartridgeResources = projectDir.resolve("src")
+                                            .resolve("main")
+                                            .resolve("resources")
+                                            .resolve("resources")
+                                            .resolve(cartridgeName);
+        Path newDBInitProperties = cartridgeResources.resolve("dbinit.properties");
+
+        // TODO open: check file attributes (writable)
+        if (newDBInitProperties.toFile().isFile() && newDBInitProperties.toFile().exists())
+        {
+            LOGGER.debug("'dbinit.properties' to have SiteContentPreparer located at '{}'", newDBInitProperties);
+            return newDBInitProperties;
+        }
+
+        Path oldDBinitProperties = projectDir.resolve("staticfiles").resolve("cartridge").resolve("dbinit.properties");
+
+        if (oldDBinitProperties.toFile().isFile() && oldDBinitProperties.toFile().exists())
+        {
+            LOGGER.debug("'dbinit.properties' to have SiteContentPreparer located at '{}'", oldDBinitProperties);
+            return oldDBinitProperties;
+        }
+
+        try
+        {
+            LOGGER.debug("No 'dbinit.properties' found. Creating new file at '{}'", newDBInitProperties);
+            // TODO open: check permission to create file (writable)
+            return Files.createFile(newDBInitProperties);
+        }
+        catch(IOException e)
+        {
+            throw new RuntimeException("Could not create file " + newDBInitProperties, e);
+        }
+    }
+
+    /**
+     * Adds the SiteContentPreparer to the dbinit.properties file at the first
+     * possible position. The preparer is added to the 'pre' namespace with the
+     * first available class ID.
+     * <p>
+     * Assumption: The pre classes are in the file before the normal preparer
+     * classes. All registered preparers are in ascending order. The check if
+     * the SiteContentPreparer is already registered is done beforehand.
+     *
+     * @param lines current lines of the dbinit.properties file
+     * @return string to be written to the dbinit.properties file
+     */
+    protected String injectSiteContentPreparer(List<String> lines)
+    {
+        StringBuilder result = new StringBuilder();
+        int preparerClassID = 0;
+        boolean added = false;
+
+        for (String line : lines)
+        {
+            // skip empty lines, comments and other preparers in the 'pre' namespace
+            String trimmedLine = line.trim();
+            // TODO skip empty lines too - but current approach causes issues when doing so
+            if (trimmedLine.startsWith("#") || line.trim().startsWith("pre.Class"))
+            {
+                if (line.trim().startsWith("pre.Class"))
+                {
+                    String[] pair = line.split("=");
+                    String classID = pair[0].trim().replace("pre.Class", "");
+                    if (classID.matches("\\d+"))
+                    {
+                        preparerClassID = Integer.parseInt(classID);
+                        if (preparerClassID > 0)
+                        {
+                            preparerClassID++;
+                        }
+                    }
+                }
+                result.append(line).append(LINE_SEP);
+                continue;
+            }
+
+            if (!added)
+            {
+                // add the new preparer
+                result.append("# Prepare sites-folder")
+                      .append(LINE_SEP);
+                result.append("pre.Class").append(preparerClassID)
+                      .append("=com.intershop.site.dbinit.SiteContentPreparer")
+                      .append(LINE_SEP)
+                      .append(LINE_SEP);
+                added = true;
+            }
+            else
+            {
+                // add the rest of the lines
+                result.append(line).append(LINE_SEP);
+            }
+        }
+
+        return result.toString();
+    }
+}

--- a/migration/src/main/java/com/intershop/customization/migration/parser/DBInitPropertiesParser.java
+++ b/migration/src/main/java/com/intershop/customization/migration/parser/DBInitPropertiesParser.java
@@ -1,0 +1,215 @@
+package com.intershop.customization.migration.parser;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Parser for the `dbinit.properties` file. This class processes the file
+ * and returns a list of entries representing the lines of the file.
+ * The class is instantiable and requires a `Path` object for initialization.
+ */
+public class DBInitPropertiesParser
+{
+    private final Logger LOGGER = LoggerFactory.getLogger(getClass());
+
+    private List<LineEntry> parsedLines;
+    Map<GroupType, PropertyEntry> firstEntries;
+    private Map<GroupType, PropertyEntry> highestIdEntries;
+
+    /**
+     * Constructor that accepts the path to the `dbinit.properties` file.
+     *
+     * @param lines the preread lines of the `dbinit.properties` file
+     */
+    public DBInitPropertiesParser(List<String> lines)
+    {
+        firstEntries = new EnumMap<>(GroupType.class);
+        highestIdEntries = new EnumMap<>(GroupType.class);
+        parsedLines = parse(lines);
+    }
+
+    public List<LineEntry> getParsedLines()
+    {
+        return parsedLines;
+    }
+
+    /**
+     * GroupType is used to identify the type of instruction in the dbinit.properties file.
+     */
+    public enum GroupType
+    {
+        PRE,    // 'pre.Class' entries
+        MAIN,   // 'Class' entries
+        POST,   // 'post.Class' entries
+        UNKNOWN // lines that do not match any of the above
+    }
+
+    /**
+     * LineEntry is a sealed interface that represents a line in the dbinit.properties file.
+     * It can be a blank line, a comment line, or a property entry.
+     */
+    public sealed interface LineEntry permits BlankLine, CommentLine, PropertyEntry
+    {
+        String LINE_SEP = System.lineSeparator();
+
+        int lineNumber();
+
+        String text();
+    }
+
+    /**
+     * Represents a blank line.
+     */
+    public record BlankLine(int lineNumber) implements LineEntry
+    {
+        @Override
+        public String text()
+        {
+            return "";
+        }
+    }
+
+    /**
+     * Represents a comment line.
+     *
+     * @param lineNumber the line number where the comment is found
+     * @param text the comment itself
+     */
+    public record CommentLine(int lineNumber, String text) implements LineEntry
+    {
+    }
+
+    /**
+     * Represents a property entry in the `dbinit.properties` file.
+     *
+     * @param lineNumber the line number where the property is found
+     * @param group the group type of the property (PRE, MAIN, POST, UNKNOWN)
+     * @param id the ID of the property (in case of compound IDs, only the first part is used)
+     * @param key the key of the property
+     * @param value the value of the property
+     * @param comments list of comments associated with the property
+     */
+    public record PropertyEntry(int lineNumber, GroupType group, Integer id, String key, String value, List<String> comments)
+                    implements LineEntry
+    {
+        @Override
+        public String text()
+        {
+            return comments.stream().map(String::trim).reduce("", (a, b) -> a + LINE_SEP + b)
+                            + LINE_SEP + key + "=" + value;
+        }
+    }
+
+    /**
+     * Helper function to detect the group type of given key based on its prefix.
+     *
+     * @param key the key to check
+     * @return the group type (PRE, MAIN, POST, UNKNOWN)
+     */
+    private static GroupType detectGroup(String key)
+    {
+        if (key.startsWith("pre.Class")) return GroupType.PRE;
+        if (key.startsWith("post.Class")) return GroupType.POST;
+        if (key.startsWith("Class")) return GroupType.MAIN;
+        return GroupType.UNKNOWN;
+    }
+
+    /**
+     * Parses the `dbinit.properties` file and returns a list of LineEntry objects.
+     *
+     * @return the list of LineEntry objects
+     */
+    protected List<LineEntry> parse(List<String> lines)
+    {
+        List<LineEntry> result = new ArrayList<>();
+        List<String> commentBuffer = new ArrayList<>();
+        int lineNumber = 0;
+
+        Pattern propertyPattern = Pattern.compile("^\\s*([^#\\s][^=]*)=(.*)$");
+        Pattern idPattern = Pattern.compile("(\\d+)(?:\\..*)?$");
+
+        for (String line : lines)
+        {
+            lineNumber++;
+            String trimmed = line.trim();
+
+            if (trimmed.isEmpty())
+            {
+                // Blank line: comments before it are "independent"
+                for (String c : commentBuffer)
+                {
+                    result.add(new CommentLine(lineNumber, c));
+                }
+                commentBuffer.clear();
+                result.add(new BlankLine(lineNumber));
+            }
+            else if (trimmed.startsWith("#") || trimmed.startsWith(";"))
+            {
+                // Comment: collect it
+                commentBuffer.add(line);
+            }
+            else
+            {
+                // Property line
+                Matcher m = propertyPattern.matcher(line);
+                if (m.find())
+                {
+                    String key = m.group(1).trim();
+                    String value = m.group(2).trim();
+                    GroupType group = detectGroup(key);
+
+                    Matcher idMatcher = idPattern.matcher(key);
+                    int id = idMatcher.find() ? Integer.parseInt(idMatcher.group(1)) : 0;
+
+                    PropertyEntry entry = new PropertyEntry(lineNumber, group, id, key, value, new ArrayList<>(commentBuffer));
+                    result.add(entry);
+                    commentBuffer.clear();
+
+                    // Store the first entry for each group
+                    firstEntries.putIfAbsent(group, entry);
+
+                    // Update highestIdEntries
+                    highestIdEntries.merge(group, entry, (existing, newEntry) -> {
+                        Matcher existingMatcher = idPattern.matcher(existing.key());
+                        int existingId = existingMatcher.find() ? Integer.parseInt(existingMatcher.group(1)) : -1;
+                        return id > existingId ? newEntry : existing;
+                    });
+                }
+                else
+                {
+                    // Fallback: handle unrecognized lines as comments
+                    result.add(new CommentLine(lineNumber, line));
+                }
+            }
+        }
+        // Add remaining comments at the end
+        for (String c : commentBuffer)
+        {
+            result.add(new CommentLine(lineNumber, c));
+        }
+        return result;
+    }
+
+    public DBInitPropertiesParser.PropertyEntry getFirstEntry(GroupType group)
+    {
+        return firstEntries.get(group);
+    }
+
+    public DBInitPropertiesParser.PropertyEntry getHighestIdEntry(GroupType group)
+    {
+        return highestIdEntries.get(group);
+    }
+}

--- a/migration/src/main/resources/migration/001_migration_7.10-11.0.8/009_AddSiteContentPreparer.yml
+++ b/migration/src/main/resources/migration/001_migration_7.10-11.0.8/009_AddSiteContentPreparer.yml
@@ -1,0 +1,3 @@
+type: specs.intershop.com/v1beta/migrate
+migrator: com.intershop.customization.migration.gradle.AddSiteContentPreparer
+message: "refactor: inject SiteContentPreparer into 'dbinit.properties'"


### PR DESCRIPTION
Implements and integrates a migration preparer to check for presence of `sites` folder. If present, the `SiteContentPreparer` will be registered at the `dbinit.properties`.