### PR TITLE
feat: add method 'extractParsedLine' to parse property lines in DBInitPropertiesParser

### DIFF
--- a/migration/src/main/java/com/intershop/customization/migration/gradle/AddSiteContentPreparer.java
+++ b/migration/src/main/java/com/intershop/customization/migration/gradle/AddSiteContentPreparer.java
@@ -12,6 +12,7 @@ import java.util.Optional;
 import com.intershop.customization.migration.common.MigrationContext;
 import com.intershop.customization.migration.common.MigrationPreparer;
 import com.intershop.customization.migration.parser.DBInitPropertiesParser;
+import com.intershop.customization.migration.parser.GroupType;
 import com.intershop.customization.migration.utils.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -60,8 +61,8 @@ public class AddSiteContentPreparer implements MigrationPreparer
                     List<String> lines = FileUtils.readAllLines(dbinitProperties);
                     DBInitPropertiesParser parser = new DBInitPropertiesParser(lines);
                     List<DBInitPropertiesParser.LineEntry> parsedLines = parser.getParsedLines();
-                    DBInitPropertiesParser.PropertyEntry highestPreEntry = parser.getHighestIdEntry(DBInitPropertiesParser.GroupType.PRE);
-                    DBInitPropertiesParser.PropertyEntry firstMainEntry = parser.getFirstEntry(DBInitPropertiesParser.GroupType.MAIN);
+                    DBInitPropertiesParser.PropertyEntry highestPreEntry = parser.getHighestIdEntry(GroupType.PRE);
+                    DBInitPropertiesParser.PropertyEntry firstMainEntry = parser.getFirstEntry(GroupType.MAIN);
 
                     FileUtils.writeString(dbinitProperties, injectSiteContentPreparer(parsedLines, highestPreEntry, firstMainEntry));
 

--- a/migration/src/main/java/com/intershop/customization/migration/parser/GroupType.java
+++ b/migration/src/main/java/com/intershop/customization/migration/parser/GroupType.java
@@ -1,0 +1,41 @@
+package com.intershop.customization.migration.parser;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+/**
+ * GroupType is used to identify the type of instruction in the dbinit.properties file.
+ */
+public enum GroupType
+{
+    PRE("pre.Class"),       // 'pre.Class' entries
+    MAIN("Class"),          // 'Class' entries
+    POST("post.Class"),     // 'post.Class' entries
+    UNKNOWN;                       // lines that do not match any of the above
+
+    private final String prefix;
+
+    GroupType(String prefix)
+    {
+        this.prefix = prefix;
+    }
+
+    GroupType()
+    {
+        this.prefix = null;
+    }
+
+    public String prefix()
+    {
+        return prefix;
+    }
+
+    public static GroupType valueByPrefix(String prefix)
+    {
+        return Arrays.stream(values())
+                     .filter(group -> Objects.nonNull(group.prefix()))
+                     .filter(group -> prefix.startsWith(group.prefix()))
+                     .findFirst()
+                     .orElse(UNKNOWN);
+    }
+}

--- a/migration/src/test/java/com/intershop/customization/migration/parser/GroupTypeTest.java
+++ b/migration/src/test/java/com/intershop/customization/migration/parser/GroupTypeTest.java
@@ -1,0 +1,44 @@
+package com.intershop.customization.migration.parser;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+
+class GroupTypeTest {
+
+    @Test
+    void testValueByPrefix_preClass()
+    {
+        assertEquals(GroupType.PRE, GroupType.valueByPrefix("pre.Class1"));
+    }
+
+    @Test
+    void testValueByPrefix_mainClass()
+    {
+        assertEquals(GroupType.MAIN, GroupType.valueByPrefix("Class1"));
+    }
+
+    @Test
+    void testValueByPrefix_postClass()
+    {
+        assertEquals(GroupType.POST, GroupType.valueByPrefix("post.Class1"));
+    }
+
+    @Test
+    void testValueByPrefix_unknown()
+    {
+        assertEquals(GroupType.UNKNOWN, GroupType.valueByPrefix("randomKey"));
+        assertEquals(GroupType.UNKNOWN, GroupType.valueByPrefix(""));
+        assertEquals(GroupType.UNKNOWN, GroupType.valueByPrefix("preclass"));
+    }
+
+    @Test
+    void testPrefixMethod()
+    {
+        assertEquals("pre.Class", GroupType.PRE.prefix());
+        assertEquals("Class", GroupType.MAIN.prefix());
+        assertEquals("post.Class", GroupType.POST.prefix());
+        assertNull(GroupType.UNKNOWN.prefix());
+    }
+}


### PR DESCRIPTION
- Implemented extractParsedLine to extract group, id, key, and value from property lines
- Returns Optional of ParsedProperty for recognized property lines, otherwise empty