### PR TITLE
feat: add open rewrite support for migration to ICM12

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ The migration steps are located in the `migration/src/main/resources/migration` 
 migrate from one major version to another, while keeping different start points in mind and supporting a migration in more maintainable steps.
 
 * [Migration 7.10 to 11](docs/migration-7.10-11.md)
+* [Migration 11 to 12](docs/migration-11-12.md)
 
 ### Third Party Libraries
 This project re-uses code from the project [GradleKotlinConverter](https://github.com/bernaferrari/GradleKotlinConverter), licensed under the Apache License 2.0. The code from the 

--- a/docs/migration-11-12.md
+++ b/docs/migration-11-12.md
@@ -1,0 +1,46 @@
+# ICM 11 to ICM 12 Migration Steps
+
+This document outlines the migration process from ICM 11 to ICM 12, including automated steps performed by the migration tool and manual steps required afterward.
+
+## Table of Contents
+
+- [Preparation Steps](#preparation-steps)
+- [Automated Migration Steps](#automated-migration-steps)
+- [Manual Migration Steps](#manual-migration-steps)
+
+## Preparation Steps
+
+### Prepare ICM12 Branch
+
+- Ensure that the branch for migration is checked out in your local repository and is up to date with the remote repository.
+- Verify a successful Gradle build after applying the previous migration steps (from ICM 7.10 to ICM 11).
+
+## Automated Migration Steps
+
+The automated steps for migrating from 11 to 12 are defined in: `src/main/resources/migration/002_migration_11_to_12`.
+
+Example command:
+```
+gradlew migration:migrateAll -Ptarget=$ICM -Psteps=src/main/resources/migration/002_migration_11_to_12
+```
+
+### Apply Jakarta EE Migration support
+
+Migrator: `ClasspathResourceFileCopier` 
+
+Applies Jakarta EE 10+ migration recipes if required (e.g., using OpenRewrite).
+- add gradle init script `rewrite.gradle` to the root of the project
+
+## Manual Migration Steps
+
+### Run OpenRewrite on the migration project
+
+Run OpenRewrite to apply Jakarta EE migration recipes on the migration project:
+```
+gradlew --init-script rewrite.gradle rewriteRun
+```
+
+> **Note:**  
+> The migration process, especially when running OpenRewrite or other code transformation tools, can require a significant amount of memory.  
+> It is recommended to increase the maximum heap size for Gradle by setting the `GRADLE_OPTS` environment variable, for example:  
+> `set GRADLE_OPTS=-Xmx4G` (on Windows) or `export GRADLE_OPTS=-Xmx4G` (on Linux/macOS).

--- a/migration/src/main/java/com/intershop/customization/migration/file/ClasspathResourceFileCopier.java
+++ b/migration/src/main/java/com/intershop/customization/migration/file/ClasspathResourceFileCopier.java
@@ -1,0 +1,105 @@
+package com.intershop.customization.migration.file;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.Collections;
+import java.util.Map;
+
+import com.intershop.customization.migration.common.MigrationContext;
+import com.intershop.customization.migration.common.MigrationPreparer;
+import com.intershop.customization.migration.common.MigrationStep;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Copies files from the classpath resources to specified target locations in the file system.
+ * <p>
+ * The source, target, and (optional) log configurations are provided via a {@link MigrationStep} and are
+ * typically defined in a YAML configuration. This class is used as part of a migration process
+ * to prepare or update project files by copying predefined resources.
+ * </p>
+ *
+ * <p>
+ * Example YAML configuration:
+ * <pre>
+ * type: specs.intershop.com/v1beta/migrate
+ * migrator: com.intershop.customization.migration.file.ClasspathResourceFileCopier
+ * message: "refactor: copy files to root project"
+ * options:
+ *   source-map:
+ *     "rewrite" : "gradle/rewrite.gradle"
+ *   target-map:
+ *     "rewrite" : "rewrite.gradle"
+ *   log-map:
+ *     "rewrite" : "Created rewrite.gradle in root project."
+ * </pre>
+ * </p>
+ *
+ * Implements {@link MigrationPreparer} for integration with the migration framework.
+ */
+public class ClasspathResourceFileCopier implements MigrationPreparer
+{
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    private static final String YAML_KEY_SOURCE_MAP     = "source-map";
+    private static final String YAML_KEY_TARGET_MAP     = "target-map";
+    private static final String YAML_KEY_LOGGING_MAP    = "log-map";
+
+    private Map<String, String> sourceConfiguration     = Collections.emptyMap();
+    private Map<String, String> targetConfiguration     = Collections.emptyMap();
+    private Map<String, String> logConfiguration        = Collections.emptyMap();
+
+    @Override
+    public void setStep(MigrationStep step)
+    {
+        this.sourceConfiguration    = step.getOption(YAML_KEY_SOURCE_MAP);
+        this.targetConfiguration    = step.getOption(YAML_KEY_TARGET_MAP);
+        this.logConfiguration       = step.getOption(YAML_KEY_LOGGING_MAP);
+    }
+
+    @Override
+    public void migrateRoot(Path resource, MigrationContext context)
+    {
+        for (Map.Entry<String, String> sourceEntry : sourceConfiguration.entrySet())
+        {
+            String artifactName = sourceEntry.getKey();
+
+            try (InputStream inputStream = this.getClass().getClassLoader().getResourceAsStream(sourceEntry.getValue()))
+            {
+                if (inputStream == null)
+                {
+                    logger.error("Resource '{}' not found in classpath.", sourceEntry.getValue());
+                    context.recordFailure(artifactName, MigrationContext.OperationType.CREATE, resource, resource,
+                            "Resource '" + sourceEntry.getValue() + "' not found in classpath.");
+                    continue;
+                }
+
+                Path targetPath = resource.resolve(targetConfiguration.get(artifactName));
+                if (Files.exists(targetPath))
+                {
+                    logger.warn("Target file '{}' already exists and will be overwritten by resource '{}'.",
+                                    targetPath, sourceEntry.getValue());
+                }
+
+                Files.copy(inputStream, targetPath, StandardCopyOption.REPLACE_EXISTING);
+                context.recordSuccess(artifactName, MigrationContext.OperationType.CREATE, resource, targetPath);
+
+                String logMessage = logConfiguration.get(artifactName);
+                if (logMessage != null && !logMessage.isEmpty())
+                {
+                    logger.info(logMessage);
+                }
+            }
+            catch (IOException e)
+            {
+                logger.error("Error copying file: {}", e.getMessage());
+                context.recordFailure(artifactName, MigrationContext.OperationType.CREATE, resource, resource,
+                        "Error copying file: " + e.getMessage());
+            }
+        }
+    }
+}

--- a/migration/src/main/resources/gradle/rewrite.gradle
+++ b/migration/src/main/resources/gradle/rewrite.gradle
@@ -1,0 +1,27 @@
+initscript {
+    repositories {
+        maven { url "https://plugins.gradle.org/m2" }
+    }
+    dependencies { classpath("org.openrewrite:plugin:7.7.0") }
+}
+rootProject {
+    plugins.apply(org.openrewrite.gradle.RewritePlugin)
+    dependencies {
+        rewrite("org.openrewrite.recipe:rewrite-migrate-java:3.11.0")
+    }
+    rewrite {
+        // see https://docs.openrewrite.org/recipes/java/migrate/jakarta/jakartaee10
+        activeRecipe("org.openrewrite.java.migrate.jakarta.JakartaEE10")
+        // see https://docs.openrewrite.org/recipes/java/migrate/upgradetojava21
+        activeRecipe("org.openrewrite.java.migrate.UpgradeToJava21")
+        // add any additional recipes here you want to run
+        setExportDatatables(true)
+    }
+    afterEvaluate {
+        if (repositories.isEmpty()) {
+            repositories {
+                mavenCentral()
+            }
+        }
+    }
+}

--- a/migration/src/main/resources/migration/002_migration_11_to_12/005_ClasspathResourceFileCopier.yaml
+++ b/migration/src/main/resources/migration/002_migration_11_to_12/005_ClasspathResourceFileCopier.yaml
@@ -1,0 +1,13 @@
+type: specs.intershop.com/v1beta/migrate
+migrator: com.intershop.customization.migration.file.ClasspathResourceFileCopier
+message: "refactor: copy files to root project"
+options:
+  source-map:
+    # source file located in the resources directory
+    "rewrite" : "gradle/rewrite.gradle"
+  target-map:
+    # target file in the root project
+    "rewrite" : "rewrite.gradle"
+  log-map:
+    # optional log message for the copied file
+    "rewrite" : "Created rewrite.gradle in root project. Adjust the file to your needs and execute 'gradle --init-script rewrite.gradle rewriteRun' afterwards."


### PR DESCRIPTION
Migrate project from ICM 11 to ICM 12

- Add migration documentation for ICM 11 to 12 in docs/migration-11-12.md
- Add Gradle init script rewrite.gradle for OpenRewrite Jakarta EE and Java 21 migration
- Update migration instructions and manual steps for Jakarta EE 10+ and Java 21 upgrade
- Reference new migration steps and automated migration tool usage in documentation