### PR TITLE
Bugfix/enhance environment example files

### DIFF
--- a/migration/src/main/resources/environment/environment.bat.example.template
+++ b/migration/src/main/resources/environment/environment.bat.example.template
@@ -17,22 +17,21 @@
 @echo off
 
 ::
-:: Make sure GRADLE_USER_HOME is defined: dir %GRADLE_USER_HOME%
-:: Set repoUser/repoPassword as well as localVersion in your %GRADLE_USER_HOME%\gradle.properties
+:: Make sure GRADLE_USER_HOME is defined and set repoUser/repoPassword and localVersion in your %GRADLE_USER_HOME%\gradle.properties
 ::
-"ADJUST YOUR gradle.properties (and then comment out this line here)"
-REM  Hint: You can either have a single GRADLE_USER_HOME for all your projects (mostly the case) or separate GRADLE_USER_HOMEs for each project (recommended)
+REM Hint: Due to the Azure Personal Access Token (PAT) it is strongly recommended to have separate GRADLE_USER_HOMEs for each project!
+REM Recommendation: Use one GRADLE_USER_HOME per Azure DevOps (ADO) organization
 REM %GRADLE_USER_HOME%\gradle.properties: repoUser={Azure DevOps user name} (e.g. XXxxxxxx@intershop.com)
 REM %GRADLE_USER_HOME%\gradle.properties: repoPassword={Azure Personal Access Token (PAT)} (e.g. ekp**********************************************rnq)
-REM  Hint: You can create one Azure Personal Access Token (PAT) for all your Azure DevOps (ADO) projects (Access scope: Global access / All accessible organizations)
-REM %GRADLE_USER_HOME%\gradle.properties: localVersion=true
-REM  (This is to avoid old code versions to be used by the app server and to avoid the messages during startAS like: "WARN: Found multiple jar files in: {cartridge}...")
+REM %GRADLE_USER_HOME%\gradle.properties: localVersion=true (to avoid use of old JARs / startAS messages: "WARN: Found multiple jar files in: {cartridge}...")
 REM Please do not confuse the %GRADLE_USER_HOME%\gradle.properties with the gradle.properties in the project root folder! Both are for completely different purposes.
+ADJUST-TO-YOUR-PATH-AND-CREATE-OR-ADJUST-THE gradle.properties IN-THIS-PATH-and-then-comment-out-this-line-here
+SET GRADLE_USER_HOME=D:\gradle_user_home\<adoOrganizationName>
 
 ::
 :: Verify AdoptOpenJDK 21 is used. (ICM11: AdoptOpenJDK 17, ICM12/13/14: AdoptOpenJDK 21)
 ::
-"ADJUST TO YOUR PATH IN THE LINE BELOW (and then comment out this line here)"
+ADJUST-TO-YOUR-PATH-IN-THE-LINE-BELOW-and-then-comment-out-this-line-here
 set JAVA_HOME=C:\Program Files\Eclipse Adoptium\jdk-21.0.9.10-hotspot
 
 ::
@@ -42,21 +41,22 @@ REM The default path to icm.properties is: CONFIGDIR=%GRADLE_USER_HOME%\icm-defa
 REM But since you can have more than one ICM11+ project on your computer and more than one app server per project,
 REM it is recommended to use project / Docker container specific icm.properties file locations!
 REM You should use the rootProject.name defined in settings.gradle.kts (also used as containerProjectPrefix for the Docker containers).
-"ADJUST TO YOUR PATH IN THE LINE BELOW (and then comment out this line here)"
+ADJUST-TO-YOUR-PATH-IN-THE-LINE-BELOW-and-then-comment-out-this-line-here
 SET CONFIGDIR=%GRADLE_USER_HOME%\<rootProject.name in settings.gradle.kts>\conf
 
 ::
 :: IStudio WORKSPACE and aliases/doskeys
 ::
-"ADJUST TO YOUR PATH IN THE LINE BELOW (and then comment out this line here)"
+ADJUST-TO-YOUR-PATH-IN-THE-LINE-BELOW-and-then-comment-out-this-line-here
 SET WORKSPACE=D:\IntershopStudio\workspace
 
 REM IStudio releases: https://knowledge.intershop.com/prd/index.php/Product/41762aa5-2396-11e9-a617-0050568a6a29
-REM IStudio versions recommended for ICM11/12/13/14 (as of 2026-Feb-26): 4.38.0 (latest GA, with AI support by GitHub Copilot)
+REM IStudio versions recommended for ICM11/12/13/14 (as of 2026-Jul-01): 4.39.1 (latest GA)
 REM Set aliases "openStudio*" and use a dedicated workspace for each IStudio version and project (and may be even branch)
-"ADJUST TO YOUR PATH AND WORKSPACE NAME IN THE LINES BELOW (and then comment out this line here)"
-doskey openStudio     = D:\IntershopStudio\IntershopStudio_4.38.0\IntershopStudio.exe -data %WORKSPACE%\<rootProject.name in settings.gradle.kts>_IStudio4.38.0
-doskey openStudio4380 = D:\IntershopStudio\IntershopStudio_4.38.0\IntershopStudio.exe -data %WORKSPACE%\<rootProject.name in settings.gradle.kts>_IStudio4.38.0
+ADJUST-TO-YOUR-PATH-AND-WORKSPACE-NAME-IN-THE-LINES-BELOW-and-then-comment-out-this-line-here
+doskey openStudio     = D:\IntershopStudio\IntershopStudio_4.39.1\IntershopStudio.exe -data %WORKSPACE%\<rootProject.name in settings.gradle.kts>_IStudio4.39.1
+doskey openStudio4391 = D:\IntershopStudio\IntershopStudio_4.39.1\IntershopStudio.exe -data %WORKSPACE%\<rootProject.name in settings.gradle.kts>_IStudio4.39.1
+doskey openStudio4400 = D:\IntershopStudio\IntershopStudio_4.40.0\IntershopStudio.exe -data %WORKSPACE%\<rootProject.name in settings.gradle.kts>_IStudio4.40.0
 
 ::
 :: dozzle - Docker log viewer - configured to host port 8888 by default. Check container "dozzle" is running in Docker Desktop, open http://localhost:8888 in browser.
@@ -72,7 +72,7 @@ PROMPT $D$H$H$H$H $T$H$H$H %IS_INSTALLATION%$B$P$G
 ::
 :: See https://knowledge.intershop.com/kb/index.php/Display/30669A "Guide - Access to Intershop Docker Images"
 ::
-"ADJUST TO YOUR Intershop Docker registry https://docker.tools.intershop.com (Harbor) "Username" AND "CLI secret" IN THE LINE BELOW (and then comment out this line here)"
+ADJUST-TO-YOUR-Intershop-Docker-registry https://docker.tools.intershop.com (Harbor) "Username" AND "CLI secret" IN-THE-LINE-BELOW-and-then-comment-out-this-line-here
 ECHO docker login docker.tools.intershop.com -u {your Intershop Docker registry Username, e.g. X.Xxxxxxx@intershop.de} -p ********************************
 docker login docker.tools.intershop.com -u {your Intershop Docker registry Username, e.g. X.Xxxxxxx@intershop.de} -p {your Intershop Docker registry CLI secret}
 
@@ -110,5 +110,6 @@ echo --------------------------------------------------------------------------
 echo dozzle                           (docker run --name dozzle --detach --volume=/var/run/docker.sock:/var/run/docker.sock -p 8888:8080 amir20/dozzle:latest)
 echo --------------------------------------------------------------------------
 echo openStudio                       (open Intershop Studio:)
-echo openStudio4380                   (D:\IntershopStudio\IntershopStudio_4.38.0\IntershopStudio.exe -data %WORKSPACE%\<rootProject.name in settings.gradle.kts>_IStudio4.38.0)
+echo openStudio4391                   (D:\IntershopStudio\IntershopStudio_4.39.1\IntershopStudio.exe -data %WORKSPACE%\<rootProject.name in settings.gradle.kts>_IStudio4.39.1)
+echo openStudio4400                   (D:\IntershopStudio\IntershopStudio_4.40.0\IntershopStudio.exe -data %WORKSPACE%\<rootProject.name in settings.gradle.kts>_IStudio4.40.0)
 echo --------------------------------------------------------------------------

--- a/migration/src/main/resources/environment/environment.sh.example.template
+++ b/migration/src/main/resources/environment/environment.sh.example.template
@@ -14,16 +14,15 @@
 #
 ##############################################################################
 
-# Make sure GRADLE_USER_HOME is defined
-#  Hint: You can either have a single GRADLE_USER_HOME for all your projects (mostly the case) or separate GRADLE_USER_HOMEs for each project (recommended)
+# Make sure GRADLE_USER_HOME is defined and set repoUser/repoPassword and localVersion in your $GRADLE_USER_HOME/gradle.properties
+#  Hint: Due to the Azure Personal Access Token (PAT) it is strongly recommended to have separate GRADLE_USER_HOMEs for each project!
+#  Recommendation: Use one GRADLE_USER_HOME per Azure DevOps (ADO) organization, e.g.: export GRADLE_USER_HOME=~/.gradle/<adoOrganizationName>
 export GRADLE_USER_HOME=~/.gradle
 
 # Set repoUser/repoPassword as well as localVersion in your $GRADLE_USER_HOME/gradle.properties
 #  $GRADLE_USER_HOME/gradle.properties: repoUser=[your Azure DevOps user name here] (e.g. XXxxxxxx@intershop.com)
 #  $GRADLE_USER_HOME/gradle.properties: repoPassword=[your Azure Personal Access Token (PAT) here] (e.g. ekp**********************************************rnq)
-#   Hint: You can create one Azure Personal Access Token (PAT) for all your Azure DevOps (ADO) projects (Access scope: Global access / All accessible organizations)
-#  $GRADLE_USER_HOME/gradle.properties: localVersion=true
-#   (This is to avoid old code versions to be used by the app server and to avoid the messages during startAS like: "WARN: Found multiple jar files in: {cartridge}...")
+#  $GRADLE_USER_HOME/gradle.properties: localVersion=true (to avoid use of old JARs / startAS messages: "WARN: Found multiple jar files in: {cartridge}...")
 # Please do not confuse the $GRADLE_USER_HOME/gradle.properties with the gradle.properties in the project root folder! Both are for completely different purposes.
 
 # Make sure OpenJDK 21 is used. (ICM11: OpenJDK 17, ICM12/13/14: OpenJDK 21)
@@ -41,11 +40,12 @@ export CONFIGDIR=$GRADLE_USER_HOME/<rootProject.name in settings.gradle.kts>/con
 export WORKSPACE=~/dev/<rootProject.name in settings.gradle.kts>/workspace
 
 # IStudio releases: https://knowledge.intershop.com/prd/index.php/Product/41762aa5-2396-11e9-a617-0050568a6a29
-# IStudio versions recommended for ICM11/12/13/14 (as of 2026-Feb-26): 4.38.0 (latest GA, with AI support by GitHub Copilot)
+# IStudio versions recommended for ICM11/12/13/14 (as of 2026-Jul-01): 4.39.1 (latest GA)
 #
 # IStudio - set alias openStudio and use a dedicated workspace for each IStudio version and project (and may be even branch)
-alias     openStudio='~/dev/apps/IntershopStudio_4.38.0/IntershopStudio -data $WORKSPACE/<rootProject.name in settings.gradle.kts>_IStudio4.38.0'
-alias openStudio4380='~/dev/apps/IntershopStudio_4.38.0/IntershopStudio -data $WORKSPACE/<rootProject.name in settings.gradle.kts>_IStudio4.38.0'
+alias     openStudio='~/dev/apps/IntershopStudio_4.39.1/IntershopStudio -data $WORKSPACE/<rootProject.name in settings.gradle.kts>_IStudio4.39.1'
+alias openStudio4391='~/dev/apps/IntershopStudio_4.39.1/IntershopStudio -data $WORKSPACE/<rootProject.name in settings.gradle.kts>_IStudio4.39.1'
+alias openStudio4400='~/dev/apps/IntershopStudio_4.40.0/IntershopStudio -data $WORKSPACE/<rootProject.name in settings.gradle.kts>_IStudio4.40.0'
 
 # dozzle - Docker log viewer - configured to host port 8888 by default.
 # Check container "dozzle" is running in Docker Desktop, open http://localhost:8888 in browser.
@@ -96,6 +96,7 @@ echo '--------------------------------------------------------------------------
 echo 'dozzle                           (docker run --name dozzle --detach --volume=/var/run/docker.sock:/var/run/docker.sock -p 8888:8080 amir20/dozzle:latest)'
 echo '--------------------------------------------------------------------------'
 echo 'openStudio                       (open Intershop Studio:)'
-echo 'openStudio4380                   (~/dev/apps/IntershopStudio_4.38.0/IntershopStudio -data $WORKSPACE/<rootProject.name in settings.gradle.kts>_IStudio4.38.0)'
+echo 'openStudio4391                   (~/dev/apps/IntershopStudio_4.39.1/IntershopStudio -data $WORKSPACE/<rootProject.name in settings.gradle.kts>_IStudio4.39.1)'
+echo 'openStudio4400                   (~/dev/apps/IntershopStudio_4.40.0/IntershopStudio -data $WORKSPACE/<rootProject.name in settings.gradle.kts>_IStudio4.40.0)'
 echo '--------------------------------------------------------------------------'
 echo

--- a/migration/src/main/resources/environment/icm.properties.example.template
+++ b/migration/src/main/resources/environment/icm.properties.example.template
@@ -1,5 +1,7 @@
 # This file is just an example (DB, Solr and mail server installed on local/host machine instead of using Docker containers).
 # YOU HAVE TO ADAPT IT TO FIT YOUR ENVIRONMENT AND NEEDS!!!
+# See also: Section "Configuration properties file" in the "Docker Plugins" documentation: https://github.com/IntershopCommunicationsAG/icm-docker-plugin/blob/master/README.asciidoc#PropertiesFile
+# See also: Configuration keys and default values: https://github.com/IntershopCommunicationsAG/icm-docker-plugin/blob/master/src/main/kotlin/com/intershop/gradle/icm/docker/utils/Configuration.kt
 
 # Default project prefix "<rootProject.name in settings.gradle.kts>" used for container names, volumes and network in Docker.
 # Underscores will be replaced with dashes, capital letters with lowercase.

--- a/migration/src/main/resources/environment/icm.properties.example.template
+++ b/migration/src/main/resources/environment/icm.properties.example.template
@@ -30,7 +30,7 @@ intershop.jdbc.password = !InterShop00!
 # Attention: "gradlew clean" removes <project root folder>/build completely! DB data files should be stored in another location.
 #data.folder.path = D:\\ICM\\<rootProject.name in settings.gradle.kts>_dev\\data_folder
 # See (for MSSQL container options, sa-user password, name of the actual DB,...): https://github.com/IntershopCommunicationsAG/icm-docker-plugin/blob/master/README.asciidoc#mssql
-# The following keys are required (no defaults!) for the app server to connect to the database.
+# The following keys are required (no defaults!) for the appserver to connect to the database.
 #intershop.databaseType = mssql
 #intershop.jdbc.url = jdbc:sqlserver://<rootProject.name in settings.gradle.kts>-mssql:1433;databaseName=icmtestdb
 #intershop.jdbc.user = intershop
@@ -38,7 +38,7 @@ intershop.jdbc.password = !InterShop00!
 
 # folder for sites (default: <project root folder>/build/sites_folder; formerly in IS7.10: $IS_SHARE/sites)
 # Since important configuration is stored here (e.g. in root/1/solrcloud/), created during DBPrepare only,
-# deleting it can cause the app server to fail. Thus, storing it outside the project directory might be a good idea.
+# deleting it can cause the appserver to fail. Thus, storing it outside the project directory might be a good idea.
 # Attention: "gradlew clean" removes <project root folder>/build completely! The sites should be stored in another location.
 # When setting up staging on a local DEV system: Use different folders for sites on Edit and Live,
 # and keep in mind: If DB was copied, DBPrepare steps are not executed again and you end up with an empty sites folder,
@@ -146,7 +146,13 @@ mail.smtp.port=25
 # development properties                                                                           #
 ####################################################################################################
 
-environment=development
+environment=dev
+
+# Above "environment" corresponds to "environmentName" in the INT/UAT/PRD Helm charts
+# and both is made available as system environment variable ENVIRONMENT, accessible in the appserver configuration as "environment".
+# To make below "environment.type" also available on INT/UAT/PRD, define it in the Helm charts as icm-as.environment.ENVIRONMENT_TYPE.
+# Do not change operationalContext.environmentType as it is restricted to {int,uat,prd}, used by OPS and not accessible in the appserver.
+intershop.environment.ENVIRONMENT_TYPE=environment.type=development
 
 # intershop.InstallationID / IS_INSTALLATION (usually used by log files)
 # In ICM standard there is mapping: intershop.InstallationID = ${IS_INSTALLATION}
@@ -154,7 +160,7 @@ environment=development
 #     icm-as.environment.IS_INSTALLATION (as something like: <rootProject.name in settings.gradle.kts>-int-live)
 intershop.environment.IS_INSTALLATION=IS_INSTALLATION=<rootProject.name in settings.gradle.kts>-mycomputer-local-dev-system
 
-# Prevent executing the embedded DBPrepare during application server startup.
+# Prevent executing the embedded DBPrepare during appserver startup.
 # Please use only for local DEV systems in case of issues with DBPrepare.
 #intershop.environment.NO_DB_PREPARE=intershop.preparation.embedded=false
 
@@ -162,7 +168,7 @@ intershop.environment.IS_INSTALLATION=IS_INSTALLATION=<rootProject.name in setti
 #intershop.environment.STAGINGTYPE=staging.system.type=editing
 
 # When setting up staging on a local DEV system: Define the location of the replication-clusters.xml
-# Please make sure the path exists in your app server (in the Docker container).
+# Please make sure the path exists in your appserver (in the Docker container).
 # It contains the container project prefix (/intershop/customizations/<containerProjectPrefix>/cartridges/...), that might be different in Edit and Live!
 #intershop.environment.REPLICATION_CLUSTER_CONFIG=intershop.replication.cluster.configuration = /intershop/customizations/<rootProject.name in settings.gradle.kts>/cartridges/<replicationCartridge>/build/resources/main/resources/<replicationCartridge>/replication/replication-clusters.xml
 
@@ -177,8 +183,12 @@ intershop.environment.IS_INSTALLATION=IS_INSTALLATION=<rootProject.name in setti
 
 # When setting up staging on a local DEV system: Location for transfer of Solr indexes from Edit to Live.
 # Set solr.cloudBackupLocation to the same physical location for Edit and Live
-# Keep in mind: This location is accessed by the Solr server(s), not by the ICM app servers
+# Keep in mind: This location is accessed by the Solr server(s), not by the ICM appservers
 #intershop.environment.SOLR_CLOUDBACKUPLOCATION=solr.cloudBackupLocation=D:\\solr\\backup
+
+# Configure if inconsistent indexes should be rebuild on Edit during the replication - before the backup.
+# (For solr.* properties see ac_solr_cloud.properties in ac_solr_cloud-*.jar in %GRADLE_USER_HOME%\caches)
+#intershop.environment.SOLR_REBUILDINCONSISTENTINDEXES=solr.RebuildInconsistentIndexes=true
 
 # switch auto reload on for all Intershop artifacts
 # Attention:

--- a/migration/src/main/resources/environment/icm.properties.example.template
+++ b/migration/src/main/resources/environment/icm.properties.example.template
@@ -148,6 +148,12 @@ mail.smtp.port=25
 
 environment=development
 
+# intershop.InstallationID / IS_INSTALLATION (usually used by log files)
+# In ICM standard there is mapping: intershop.InstallationID = ${IS_INSTALLATION}
+# IS_INSTALLATION should also be defined in environments Helm charts as:
+#     icm-as.environment.IS_INSTALLATION (as something like: <rootProject.name in settings.gradle.kts>-int-live)
+intershop.environment.IS_INSTALLATION=IS_INSTALLATION=<rootProject.name in settings.gradle.kts>-mycomputer-local-dev-system
+
 # Prevent executing the embedded DBPrepare during application server startup.
 # Please use only for local DEV systems in case of issues with DBPrepare.
 #intershop.environment.NO_DB_PREPARE=intershop.preparation.embedded=false


### PR DESCRIPTION
feat: tool for automatic (re-)create of example files

Enhancements:
- Recommendation: Use one GRADLE_USER_HOME per Azure DevOps (ADO) organization
    - This is due to Microsoft: Global personal access tokens (PATs) are retiring in Azure DevOps  2026-Dec-01
- "environment.type" in addition to "environment" for a possible separation of environment-specific and environment-type-specific configuration
- Updated IStudio version
- Plus some more minor enhancements