### PR TITLE
Feature/add job and appprfrnc to migrate config resources

### DIFF
--- a/migration/src/main/java/com/intershop/customization/migration/pfconfigurationfs/CfgResourceConverter.java
+++ b/migration/src/main/java/com/intershop/customization/migration/pfconfigurationfs/CfgResourceConverter.java
@@ -359,7 +359,7 @@ public class CfgResourceConverter
                     {
                         targetLines.add(targetLine);
                     }
-                    targetEntry = new ArrayList<String>();
+                    targetEntry.clear();
                 }
             }
         }
@@ -457,7 +457,7 @@ public class CfgResourceConverter
                     {
                         targetLines.add(targetLine);
                     }
-                    targetEntry = new ArrayList<String>();
+                    targetEntry.clear();
                 }
             }
         }
@@ -482,7 +482,9 @@ public class CfgResourceConverter
      * Unfortunately you cannot quote a > inside a key/name, because pf_configuration_fs does not support any quoting. (Only java.util.Properties supports it, before handing over the keys to the application.)
      * Example quoting:
      * - "My Parameter Name" --> "My\ Parameter\u0020Name"
-     * 
+     *
+     * Currently, only spaces are quoted: " " --> "\ "
+     *
      * @param key the property key to quote
      * @return the quoted property key
      */

--- a/migration/src/main/java/com/intershop/customization/migration/pfconfigurationfs/CfgResourceConverter.java
+++ b/migration/src/main/java/com/intershop/customization/migration/pfconfigurationfs/CfgResourceConverter.java
@@ -35,7 +35,17 @@ import org.slf4j.LoggerFactory;
 
 public class CfgResourceConverter
 {
-
+    public static final String PROPERTY_KEY_SEPARATOR = ">";
+    public static final String PROPERTY_KEY_PREFIX = "pfconfigurationfs";
+    public static final String PROPERTY_KEY_OBJECT_TYPE_APPLICATION = "appprfrnce";
+    public static final String PROPERTY_KEY_OBJECT_TYPE_DOMAIN      = "dmnprfrnce";
+    public static final String PROPERTY_KEY_OBJECT_TYPE_JOB         = "job";
+    public static final String PROPERTY_KEY_OBJECT_TYPE_SERVICE     = "mngdsrvc";
+    public static final String PROPERTY_KEY_OBJECT_TYPE_PAYMENT     = "pmntsrvc";
+    public static final String PROPERTY_KEY_OBJECT_TYPE_TRANSPORT   = "transport";
+    public static final String PROPERTY_KEY_OBJECT_TYPE_USER        = "usr";
+    public static final String DEFAULT_APPLICATION_URL_IDENTIFIER = "rest";
+    
     /**
      * The resource type to be converted, mapping to the resource file name.
      * <ul>
@@ -50,10 +60,14 @@ public class CfgResourceConverter
     {
         TRANSPORT("transport"), 
         APPLICATION("application"), 
+        APPPRFRNC("appprfrnc"),  // usually *.resource files
+        APPPRFRNCE("appprfrnce"),  // usually *.resource files
+        APPDMNPRF("appdmnprf"),  // usually *.properties files
         USR("usr"), 
         MNGDSRVC("mngdsrvc"), 
         PMTSRVC("pmntsrvc"), 
         DMNPRFRNCE("dmnprfrnce"), 
+        JOB("job"),
         UNKNOWN("");
 
         private final String value;
@@ -81,22 +95,38 @@ public class CfgResourceConverter
 
         public String getPrefix()
         {
-            String prfValue = "";
-            if( ResourceType.UNKNOWN.getValue().equals(this.value) ) 
+            String propertyKeyPrefix = PROPERTY_KEY_PREFIX;
+            switch (this)
             {
-                prfValue = "";
-             } 
-             else if( ResourceType.APPLICATION.getValue().equals(this.value) ) 
-             {
-                prfValue = "pfconfigurationfs>appprfrnce";
-                
-             }
-             else
-             {
-                prfValue = "pfconfigurationfs>" + this.value;
-                
-             }
-            return prfValue;
+                case TRANSPORT:
+                    propertyKeyPrefix += PROPERTY_KEY_SEPARATOR + PROPERTY_KEY_OBJECT_TYPE_TRANSPORT;
+                    break;
+                case USR:
+                    propertyKeyPrefix += PROPERTY_KEY_SEPARATOR + PROPERTY_KEY_OBJECT_TYPE_USER;
+                    break;
+                case MNGDSRVC:
+                    propertyKeyPrefix += PROPERTY_KEY_SEPARATOR + PROPERTY_KEY_OBJECT_TYPE_SERVICE;
+                    break;
+                case PMTSRVC:
+                    propertyKeyPrefix += PROPERTY_KEY_SEPARATOR + PROPERTY_KEY_OBJECT_TYPE_PAYMENT;
+                    break;
+                case DMNPRFRNCE:
+                    propertyKeyPrefix += PROPERTY_KEY_SEPARATOR + PROPERTY_KEY_OBJECT_TYPE_DOMAIN;
+                    break;
+                case JOB:
+                    propertyKeyPrefix += PROPERTY_KEY_SEPARATOR + PROPERTY_KEY_OBJECT_TYPE_JOB;
+                    break;
+                case APPLICATION:
+                case APPPRFRNC:
+                case APPPRFRNCE:
+                case APPDMNPRF:
+                    propertyKeyPrefix += PROPERTY_KEY_SEPARATOR + PROPERTY_KEY_OBJECT_TYPE_APPLICATION;
+                    break;
+                default:
+                    LOGGER.error("Unknown resource type. Unable to determine the correct property key prefix.");
+            }
+
+            return propertyKeyPrefix;
         }
     }
 
@@ -151,10 +181,16 @@ public class CfgResourceConverter
             List<String> lines = FileUtils.readAllLines(source);
             List<String> targetLines = new ArrayList<>();
 
-            if ( ResourceType.TRANSPORT == this.resourceType
-                || ResourceType.APPLICATION == this.resourceType)
+            if ( ResourceType.TRANSPORT == this.resourceType)
             {
                 targetLines = migrateTransportCfg(lines);
+            }
+            else if (ResourceType.APPLICATION == this.resourceType
+                || ResourceType.APPPRFRNC == this.resourceType
+                || ResourceType.APPPRFRNCE == this.resourceType
+                || ResourceType.APPDMNPRF == this.resourceType)  // ResourceType.APPDMNPRF ("appdmnprf") is usually a *.properties file and not a *.resource file!
+            {
+                targetLines = migrateApplicationCfg(lines);
             }
             else if (ResourceType.USR  ==this.resourceType
                      || ResourceType.DMNPRFRNCE == this.resourceType)
@@ -168,6 +204,10 @@ public class CfgResourceConverter
             else if ( ResourceType.PMTSRVC == this.resourceType)
             {
                 targetLines = migratePaymantServiceCfg(lines);
+            }
+            else if ( ResourceType.JOB == this.resourceType)
+            {
+                targetLines = migrateJobCfg(lines);
             }
             else
             {
@@ -215,7 +255,41 @@ public class CfgResourceConverter
             }
             else
             {
-                targetLine = this.resourceType.getPrefix() + ">" + line.trim();
+                targetLine = this.resourceType.getPrefix() + PROPERTY_KEY_SEPARATOR + line.trim();
+                targetLines.add(targetLine);
+            }
+        }
+        return targetLines;
+    }
+
+    /**
+     * Application domain preferences contained in a *.resource file.
+     * Usually *_appprfrnc.resource or *_appprfrnce.resource.
+     * By default, these files do not contain an explicit application (URL identifier),
+     * but a default application is not supported by ICM 11+ pf_configuration_fs yet.
+     * Using constant DEFAULT_APPLICATION_URL_IDENTIFIER = "rest".
+     * 
+     * @param lines the lines of the source file
+     * @return targetLines the lines of the target file
+     */
+    private ArrayList<String> migrateApplicationCfg(List<String> lines)
+    {
+        String targetLine = "";
+        ArrayList<String> targetLines = new ArrayList<>();
+
+        for (String line : lines)
+        {
+            line = line.trim();
+
+            // transport resource file
+            if (line.isEmpty() || (line.startsWith("#")))
+            {
+                targetLine = line;
+                targetLines.add(targetLine);
+            }
+            else
+            {
+                targetLine = this.resourceType.getPrefix() + PROPERTY_KEY_SEPARATOR + DEFAULT_APPLICATION_URL_IDENTIFIER + PROPERTY_KEY_SEPARATOR + line.trim();
                 targetLines.add(targetLine);
             }
         }
@@ -244,7 +318,7 @@ public class CfgResourceConverter
         String targetLine = "";
 
         // fuill target line
-        ArrayList<String> tartEntry = new ArrayList<>();
+        ArrayList<String> targetEntry = new ArrayList<>();
 
         for (String line : lines)
         {
@@ -261,41 +335,173 @@ public class CfgResourceConverter
                 String[] entry = line.split("=");
 
                 // scam inputz lin
-                String cfgGroup = "";
                 String cfgKey = "";
                 String cfgValue = "";
                 if (entry.length == 2)
                 {
                     cfgKey = entry[0].trim();
                     cfgValue = entry[1].trim();
-                    if (0 >= cfgKey.indexOf("."))
-                    {
-                        cfgGroup = cfgKey.substring(0, cfgKey.indexOf(".") - 1);
-                        cfgKey = cfgKey.substring(cfgKey.indexOf("."), cfgKey.length()).trim();
-                    }
                 }
 
                 // gather configuration paremeters
 
-                List<String> sourceEentry = Arrays.asList(cfgGroup, cfgKey, cfgValue);
-                if (tartEntry.size() < 3)
+                String sourceValue = cfgValue;
+                if (targetEntry.size() < 3)
                 {
-                    tartEntry.add(sourceEentry.get(2).trim());
+                    targetEntry.add(sourceValue);
                 }
-                if (tartEntry.size() == 3)
+                if (targetEntry.size() == 3)
                 {
-                    String groupStr = tartEntry.get(0).trim();
-                    targetLine = this.resourceType.getPrefix() + ">" + groupStr + ">" + tartEntry.get(1).trim() + " = "
-                                    + tartEntry.get(2).trim();
+                    String groupStr = targetEntry.get(0).trim();
+                    targetLine = this.resourceType.getPrefix() + PROPERTY_KEY_SEPARATOR + groupStr + PROPERTY_KEY_SEPARATOR + targetEntry.get(1).trim() + " = "
+                                    + targetEntry.get(2).trim();
                     if (!targetLine.endsWith(" = n/a"))
                     {
                         targetLines.add(targetLine);
                     }
-                    tartEntry = new ArrayList<String>();
+                    targetEntry = new ArrayList<String>();
                 }
             }
         }
+
+        if (targetEntry.size() > 0)
+        {
+            LOGGER.error("Incomplete configuration entry found in file {}, expecting 3 lines per configuration", source);
+        }
+
         return targetLines;
+    }
+
+    /**
+     * Similar to configurations of #type# transport and application,
+     * but EnabledFlag=true/false needs to be converted to Enabled = "true"|"false"
+     * and spaces in job names need to be escaped with a backslash.
+     * <p/>
+     * The ICM 7.10 configuration:<br/>
+     * <br/>
+     * gets converted to ICM11+:<br/>
+     * pfconfigurationfs>job>#JobName#>#AttributeName# = #Value#<br/>
+     * pfconfigurationfs>job>Regular\ Replication\ Process>ReplicationProcessID = MyReplicationProcess<br/>
+     * pfconfigurationfs>job>Regular\ Replication\ Process>Enabled = false<br/>
+     * 
+     * @param lines the lines of the source file
+     * @return targetLines the lines of the target file
+     */
+    private ArrayList<String> migrateJobCfg(List<String> lines)
+    {
+        ArrayList<String> targetLines = new ArrayList<>();
+
+        // Process and write lines to another file
+        String targetLine = "";
+
+        // fuill target line
+        ArrayList<String> targetEntry = new ArrayList<>();
+
+        for (String line : lines)
+        {
+            line = line.trim();
+
+            // job resource file
+            if (line.isEmpty() || (line.startsWith("#")))
+            {
+                targetLine = line;
+                targetLines.add(targetLine);
+            }
+            else
+            {
+                String[] entry = line.split("=");
+
+                // scan input line
+                String cfgJobName = "";
+                String cfgKey = "";
+                String cfgValue = "";
+                if (entry.length == 2)
+                {
+                    cfgKey = entry[0].trim();
+                    cfgValue = entry[1].trim();
+                }
+
+                // gather configuration parameters
+
+                String sourceValue = cfgValue;
+                if (targetEntry.size() < 3)
+                {
+                    targetEntry.add(sourceValue);
+                }
+                if (targetEntry.size() == 3)
+                {
+                    String jobName       = targetEntry.get(0);
+                    String attributeName = targetEntry.get(1);
+                    jobName       = quotePropertyKey(jobName); // Escape spaces in job name, because it is used as part of a property key in a properties file
+                    attributeName = quotePropertyKey(attributeName); // Escape spaces in attribute name, because it is used as part of a property key in a properties file
+                    if (attributeName.equalsIgnoreCase("EnabledFlag"))
+                    {
+                        attributeName = "Enabled";
+                        if (targetEntry.get(2).equalsIgnoreCase("true"))
+                        {
+                            targetEntry.set(2, "true");
+                        }
+                        else if (targetEntry.get(2).equalsIgnoreCase("false"))
+                        {
+                            targetEntry.set(2, "false");
+                        }
+                        else
+                        {
+                            // leave targetEntry as-is, but log a warning
+                            LOGGER.warn("Unexpected value for job config '{}' (job name '{}') parameter 'EnabledFlag': {}. Expected 'true' or 'false'.", cfgJobName, jobName, targetEntry.get(2));
+                        }
+                    }
+                    targetLine = this.resourceType.getPrefix() + PROPERTY_KEY_SEPARATOR + jobName + PROPERTY_KEY_SEPARATOR + attributeName + " = "
+                                    + targetEntry.get(2).trim();
+                    if (!targetLine.endsWith(" = n/a"))
+                    {
+                        targetLines.add(targetLine);
+                    }
+                    targetEntry = new ArrayList<String>();
+                }
+            }
+        }
+
+        if (targetEntry.size() > 0)
+        {
+            LOGGER.error("Incomplete configuration entry found in file {}, expecting 3 lines per job configuration", source);
+        }
+
+        return targetLines;
+    }
+
+    /**
+     * Property keys in properties files have some restrictions (see JavaDoc of java.util.Properties):
+     * Do not use spaces in the keys! Not even around the > separators!
+     * In keys you need to quote:
+     * - Space ('\ ', '\u0020')
+     * - Tab ('\t', '\u0009')
+     * - Form feed ('\f', '\u000C')
+     * - Equals sign ('\=')
+     * - Colon ('\:')
+     * Unfortunately you cannot quote a > inside a key/name, because pf_configuration_fs does not support any quoting. (Only java.util.Properties supports it, before handing over the keys to the application.)
+     * Example quoting:
+     * - "My Parameter Name" --> "My\ Parameter\u0020Name"
+     * 
+     * @param key the property key to quote
+     * @return the quoted property key
+     */
+    public static String quotePropertyKey(String key) {
+        if (key == null || key.isEmpty() || !key.contains(" ")) {
+            return key; // Nothing to change
+        }
+
+        StringBuffer quotedKey = new StringBuffer(key.length() * 2); // Allocate enough space for the worst case
+        char lastChar = '\0';
+        for (char c : key.toCharArray()) {
+            if (c == ' ' && lastChar != '\\') {
+                quotedKey.append('\\');
+            }
+            quotedKey.append(c);
+            lastChar = c;
+        }
+
+        return quotedKey.toString();
     }
 
     /**
@@ -315,7 +521,7 @@ public class CfgResourceConverter
 
         // Process and write lines to another file
         String targetLine = "";
-        HashMap<String, String> taretEntry = new HashMap<>();
+        HashMap<String, String> targetEntry = new HashMap<>();
 
         for (String line : lines)
         {
@@ -336,7 +542,7 @@ public class CfgResourceConverter
                 String cfgValue = "";
 
                 // gather the source data
-                if (taretEntry.size() < 4)
+                if (targetEntry.size() < 4)
                 {
                     // scan the source line
                     String[] entry = line.split("=");
@@ -350,11 +556,11 @@ public class CfgResourceConverter
                             cfgKey = cfgKey.substring(cfgKey.indexOf("."), cfgKey.length()).trim();
                         }
                     }
-                    taretEntry.put(cfgKey, cfgValue);
+                    targetEntry.put(cfgKey, cfgValue);
                 }
                 // all values found - build and add the target line and
                 // reset the source data
-                if (taretEntry.size() == 4)
+                if (targetEntry.size() == 4)
                 {
                     if (0 >= cfgKey.indexOf("."))
                     {
@@ -363,19 +569,25 @@ public class CfgResourceConverter
                     cfgGroup = cfgKey.substring(0, cfgKey.indexOf("."));
                     StringBuffer bTargetLine
                     = new StringBuffer().append(this.resourceType.getPrefix())
-                      .append(">")
-                      .append(taretEntry.get( cfgGroup + ".ServiceDefinitionID"))
-                      .append(">").append(taretEntry.get(cfgGroup + ".ServiceConfigurationName"))
-                      .append(">").append(taretEntry.get(cfgGroup + ".ParameterName"))
-                      .append(" = ").append(taretEntry.get(cfgGroup + ".Value"));
+                      .append(PROPERTY_KEY_SEPARATOR)
+                      .append(targetEntry.get( cfgGroup + ".ServiceDefinitionID"))
+                      .append(PROPERTY_KEY_SEPARATOR).append(targetEntry.get(cfgGroup + ".ServiceConfigurationName"))
+                      .append(PROPERTY_KEY_SEPARATOR).append(targetEntry.get(cfgGroup + ".ParameterName"))
+                      .append(" = ").append(targetEntry.get(cfgGroup + ".Value"));
 
                     targetLine = bTargetLine.toString();
                     targetLines.add(targetLine);
 
-                    taretEntry.clear();
+                    targetEntry.clear();
                 }
             }
         }
+
+        if (targetEntry.size() > 0)
+        {
+            LOGGER.error("Incomplete configuration entry found in file {}, expecting 4 lines per managed service configuration", source);
+        }
+
         return targetLines;
     }
 
@@ -396,7 +608,7 @@ public class CfgResourceConverter
 
         // Process and write lines to another file
         String targetLine = "";
-        HashMap<String, String> taretEntry = new HashMap<>();
+        HashMap<String, String> targetEntry = new HashMap<>();
 
         for (String line : lines)
         {
@@ -417,7 +629,7 @@ public class CfgResourceConverter
                 String cfgValue = "";
 
                 // gather the source data
-                if (taretEntry.size() < 4)
+                if (targetEntry.size() < 4)
                 {
                     // scan the source line
                     String[] entry = line.split("=");
@@ -431,11 +643,11 @@ public class CfgResourceConverter
                             cfgKey = cfgKey.substring(cfgKey.indexOf("."), cfgKey.length()).trim();
                         }
                     }
-                    taretEntry.put(cfgKey, cfgValue);
+                    targetEntry.put(cfgKey, cfgValue);
                 }
                 // all values found - build and add the target line and
                 // reset the source data
-                if (taretEntry.size() == 4)
+                if (targetEntry.size() == 4)
                 {
                     if (0 >= cfgKey.indexOf("."))
                     {
@@ -444,19 +656,25 @@ public class CfgResourceConverter
                     cfgGroup = cfgKey.substring(0, cfgKey.indexOf("."));
                     StringBuffer bTargetLine
                     = new StringBuffer().append(this.resourceType.getPrefix())
-                      .append(">")
-                      .append(taretEntry.get( cfgGroup + ".PaymentServiceID"))
-                      .append(">").append(taretEntry.get(cfgGroup + ".PaymentServiceConfigurationID"))
-                      .append(">").append(taretEntry.get(cfgGroup + ".ParameterName"))
-                      .append(" = ").append(taretEntry.get(cfgGroup + ".Value"));
+                      .append(PROPERTY_KEY_SEPARATOR)
+                      .append(targetEntry.get( cfgGroup + ".PaymentServiceID"))
+                      .append(PROPERTY_KEY_SEPARATOR).append(targetEntry.get(cfgGroup + ".PaymentServiceConfigurationID"))
+                      .append(PROPERTY_KEY_SEPARATOR).append(targetEntry.get(cfgGroup + ".ParameterName"))
+                      .append(" = ").append(targetEntry.get(cfgGroup + ".Value"));
 
                     targetLine = bTargetLine.toString();
                     targetLines.add(targetLine);
 
-                    taretEntry.clear();
+                    targetEntry.clear();
                 }
             }
         }
+
+        if (targetEntry.size() > 0)
+        {
+            LOGGER.error("Incomplete configuration entry found in file {}, expecting 4 lines per payment service configuration", source);
+        }
+
         return targetLines;
     }
 }

--- a/migration/src/main/java/com/intershop/customization/migration/pfconfigurationfs/ConfigurationXMLBuilder.java
+++ b/migration/src/main/java/com/intershop/customization/migration/pfconfigurationfs/ConfigurationXMLBuilder.java
@@ -8,8 +8,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import com.intershop.customization.migration.pfconfigurationfs.CfgResourceConverter.ResourceType;
-
 /**
  * This method would contain logic to build the XML configuration
  * based on the cartridge name and the provided configuration XML.
@@ -34,11 +32,11 @@ public class ConfigurationXMLBuilder {
 
     private static final String SCOPE_DOMAIN                = "domain";
 
-    private static final String PLACEHOLDER_ENVIRONMENT     ="\\$\\{environment\\}";
+    private static final String PLACEHOLDER_ENVIRONMENT     ="${environment}";
     // LinkedHashMap to keep the order of replacements - e.g. the issue with (pre)production
     private static final Map<String, String> environments   = new LinkedHashMap<>();
 
-    private static final String PLACEHOLDER_STAGING_SYSTEM_TYPE ="\\$\\{staging.system.type\\}";
+    private static final String PLACEHOLDER_STAGING_SYSTEM_TYPE ="${staging.system.type}";
     private static final Map<String, String> systemTypes        = new HashMap<>();
 
     private String lastDopmainName ="";
@@ -57,13 +55,21 @@ public class ConfigurationXMLBuilder {
         footerLines.add("\t</sets>");
         footerLines.add("</configuration-setup>");
         
+        // environment types
+        environments.put("development",      PLACEHOLDER_ENVIRONMENT);
+        environments.put("integration",      PLACEHOLDER_ENVIRONMENT);
+        environments.put("preproduction",    PLACEHOLDER_ENVIRONMENT);
+        environments.put("production",       PLACEHOLDER_ENVIRONMENT);
         // environments
-        environments.put("development",     PLACEHOLDER_ENVIRONMENT);        
-        environments.put("integration",     PLACEHOLDER_ENVIRONMENT);        
-        environments.put("preproduction",   PLACEHOLDER_ENVIRONMENT);        
-        environments.put("production",      PLACEHOLDER_ENVIRONMENT);        
+        environments.put("test",             PLACEHOLDER_ENVIRONMENT);
+        environments.put("testa",            PLACEHOLDER_ENVIRONMENT);
+        environments.put("testb",            PLACEHOLDER_ENVIRONMENT);
+        environments.put("acceptance",       PLACEHOLDER_ENVIRONMENT);
+        environments.put("acceptancea",      PLACEHOLDER_ENVIRONMENT);
+        environments.put("acceptanceb",      PLACEHOLDER_ENVIRONMENT);
 
         // staging system types
+        systemTypes.put("none",     PLACEHOLDER_STAGING_SYSTEM_TYPE);
         systemTypes.put("editing",  PLACEHOLDER_STAGING_SYSTEM_TYPE);
         systemTypes.put("live",     PLACEHOLDER_STAGING_SYSTEM_TYPE);
     
@@ -106,13 +112,45 @@ public class ConfigurationXMLBuilder {
         .replaceFirst( "^.*" + this.cartridgeName+".config", "config");
 
         // set variables or environment and staging system type in the file name
-        for(Map.Entry<String, String> env: environments.entrySet())
+        int lastSlash = cfgFileName.lastIndexOf('/');
+        int dot = cfgFileName.lastIndexOf('.');
+        if (lastSlash >= 0 && dot >= 0 && dot > lastSlash)
         {
-            cfgFileName = cfgFileName.replaceAll(env.getKey(), env.getValue());
+            String fileName = cfgFileName.substring(lastSlash + 1, dot);  // pure file name without path and extension
+            StringBuilder cfgFileNameWithPlaceholders = new StringBuilder();
+            cfgFileNameWithPlaceholders.append(cfgFileName.substring(0, lastSlash + 1));  // add the path up to the last slash before the file name
+            // split filename at "_", "-" and "." and keep the separators in the resulting array
+            String[] splitFileName = fileName.split("((?=_|\\-|\\.)|(?<=_|\\-|\\.))");
+            for(String part: splitFileName)
+            {
+                for(Map.Entry<String, String> env: environments.entrySet())
+                {
+                    if (part.equals(env.getKey()))
+                    {
+                        part = env.getValue();
+                    }
+                }
+                
+                for(Map.Entry<String, String> sys: systemTypes.entrySet())
+                {
+                    if (part.equals(sys.getKey()))
+                    {
+                        part = sys.getValue();
+                    }
+                }
+                
+                cfgFileNameWithPlaceholders.append(part);
+            }
+
+            fileName = cfgFileNameWithPlaceholders.toString();
+
+            cfgFileNameWithPlaceholders.append(cfgFileName.substring(dot));  // add the extension incl. the dot
+
+            cfgFileName = cfgFileNameWithPlaceholders.toString();
         }
-        for(Map.Entry<String, String> sys: systemTypes.entrySet())
+        else
         {
-            cfgFileName = cfgFileName.replaceAll(sys.getKey(), sys.getValue());
+            MigrateConfigResources.LOGGER.warn("Unable to determine file name from path '{}': index of last slash = {}, index of dot = {}", cfgFileName, lastSlash, dot);
         }
 
         // count up priority by domain starting with 60 for each of them


### PR DESCRIPTION
feat: extend 050_MigrateConfigResources to migrate more types of resource files

Feature description:
- "Test System Configuration Solution Kit" (cartridge pf_configuration_fs) was using *.resource files in share/system/config/domains in IS 7.10 and in ICM 11+ it uses regular *.properties files instead
- ICM Migration Support step 001_migration_7x10_to_11/050_MigrateConfigResources.yml transforms the *.resource files into *.properties files and wires the *.properties files in configuration.xml

Changes:
- In addition to "transport", "application", "usr", "mngdsrvc", "pmntsrvc", "dmnprfrnce",
it now also supports *.resource files of type "appprfrnc", "appprfrnce", "appdmnprf" and "job"
- Enhancements for placeholders in files names (written into configuration.xml files)

The changes were already tested in migration projects Soennecken, Quadient and Rijk Zwaan, committed by Quadient and the feature branch has already been handed over to Rijk Zwaan for executing the migration.
